### PR TITLE
servers: remove SSL FPs, fix typo & Matrix link

### DIFF
--- a/www/servers.html
+++ b/www/servers.html
@@ -52,9 +52,6 @@
       <strong>admins</strong>: <a href="mailto:scoffa@pirateirc.net">Scoffa</a>, <a href="mailto:mikaela.suomalainen@piraattipuolue.fi">Mikaela</a></br>
       <strong>features</strong>: IPv4, SSL (commercial / verifiable), SASL</br>
       <strong>ports</strong>: 6667 (standard), 6697 (SSL)</br>
-      <ul>SSL fingerprints
-      <li><strong>SHA1</strong>: E0:AA:92:42:FE:A7:E3:11:6B:2B:46:50:B8:5C:D0:94:A1:45:6E:95</li>
-      <li><strong>SHA256</strong>: 6D:CD:99:36:15:D6:F6:BD:DC:09:42:EF:5D:D7:5A:77:EB:8E:E2:7A:B7:7E:C8:AF:31:06:2D:D6:4A:5E:37:FF</li></ul></p>
       <div class="line"></div>
 
       <h3>Stockholm-se.pirateirc.net</h3>
@@ -63,9 +60,6 @@
       <strong>admins</strong>: <a href="mailto:olan@pirateirc.net">OlaN</a>, Milliways</br>
       <strong>features</strong>: IPv4, IPv6, SSL (commercial / verifiable), SASL</br>
       <strong>ports</strong>: 6667, 8080 (standard), 6697, 9090 (SSL)</br>
-      <ul>SSL fingerprints
-      <li><strong>SHA1</strong>: 28:07:AA:22:9E:8A:C0:BD:53:62:C8:75:CD:65:05:D1:E0:36:FB:60</li>
-      <li><strong>SHA256</strong>: 30:10:72:5F:92:4A:58:0A:6A:8E:9F:A0:05:64:21:E3:89:94:00:FB:30:54:DC:8B:FD:A7:0E:5B:36:E0:42:C0</li></ul></p>
       <div class="line"></div>
 
       <h3>Sydney-au.pirateirc.net</h3>
@@ -74,16 +68,13 @@
       <strong>admins</strong>: <a href="mailto:fletcher.boyd@pirateparty.org.au">Fletcher</a> (PGP: 5BAE 331E 9B57 3709 6E6A 19ED 85B8 D7B6 60D5 D803)</br>
       <strong>features</strong>: IPv4, IPv6, SSL (commercial / verifiable), SASL</br>
       <strong>ports</strong>: 6667 (standard), 6697 (SSL)</br>
-      <ul>SSL fingerprints
-      <li><strong>SHA1</strong>: C0:55:84:58:AB:0C:7C:C6:07:1A:0B:56:79:98:17:9C:3B:4A:BD:D9</li>
-      <li><strong>SHA256</strong>: C9:3E:BA:4D:43:4D:C9:E5:33:67:72:32:62:E9:D1:F3:C0:68:F7:F7:23:B3:37:BF:C0:2A:A0:F9:A3:4D:84:F5</li></ul></p>
       <div class="line"></div>
 
       <h3>Matrix Bridge</h3>
       <p><strong>site</strong>: <a href="https://diasp.in">diasp.in</a></br>
       <strong>admin</strong>: <a href="mailto:noteness@riseup.net">Noteness</a> (PGP: 5EA4 60AE EE37 8B62 F672 D906 5C20 98DC 4DF7 C1CA)</br>
       <strong>features</strong>: Bridges all PirateIRC rooms to a federated Matrix server.</br>
-      <strong>connecting</strong>: #pirateirc_#your-channel:diasp.in from any federated homeserver. (like <a href="https://matrix.org">Matrix.org</a></br>
+      <strong>connecting</strong>: #pirateirc_#your-channel:diasp.in from any federated homeserver. (<a href="https://www.hello-matrix.net/public_servers.php">Unofficial list of public Matrix homeservers.</a>)</br>
       <div class="clear"></div>
     
     <!-- Begin Footer -->


### PR DESCRIPTION
I think that the SSL fingerprints are useless to list as they change so
often. I suggested listing the domains that they are valid for, but I
think there is time for that later.

I added missing bracket and changed the link from matrix.org to list of
unofficial public homeservers.