### PR TITLE
parties: remove empty channels & fix names

### DIFF
--- a/www/parties.html
+++ b/www/parties.html
@@ -53,8 +53,8 @@
     <p><strong>party</strong>: Piratpartiet Sweden</p>
     <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=piratpartiet">#piratpartiet</a></p>
     <div class="line"></div>
-    <p><strong>party</strong>: Piraattipuolue Finland</p>
-    <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=piraatit">#piraatit</a></p>
+    <p><strong>party</strong>: Piraattipuolue Finland &amp; Piraattinuoret Finland</p>
+    <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=#piraatit,#piraattinuoret">#piraatit,#piraattinuoret</a></p>
     <div class="line"></div>
     <p><strong>party</strong>: Piratpartiet Norway</p>
     <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=piratpartiet.no">#piratpartiet.no</a></p>

--- a/www/parties.html
+++ b/www/parties.html
@@ -54,7 +54,7 @@
     <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=piratpartiet">#piratpartiet</a></p>
     <div class="line"></div>
     <p><strong>party</strong>: Piraattipuolue Finland</p>
-    <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=piraattipuolue">#piraattipuolue</a></p>
+    <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=piraatit">#piraatit</a></p>
     <div class="line"></div>
     <p><strong>party</strong>: Piratpartiet Norway</p>
     <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=piratpartiet.no">#piratpartiet.no</a></p>
@@ -77,26 +77,14 @@
     <p><strong>party</strong>: Pirate Party Estonia</p>
     <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=piraadipartei">#piraadipartei</a></p>
     <div class="line"></div>
-    <p><strong>party</strong>: Pirate Party of Poland</p>
-    <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=partiapiratow">#partiapiratow</a></p>
-    <div class="line"></div>
     <p><strong>party</strong>: United States Pirate Party (currently an unofficial/unregistered party)</p>
     <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=uspp">#uspp</a></p>
     <div class="line"></div>
     <p><strong>party</strong>: Pirate Party New Zealand (currently an unofficial/unregistered party)</p>
     <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=ppnz">#ppnz</a></p>
     <div class="line"></div>
-    <p><strong>party</strong>: Pirate Party Greece (currently an unofficial/unregistered party)</p>
-    <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=ppgr">#ppgr</a></p>
-    <div class="line"></div>
-    <p><strong>party</strong>: Pirate Party Turkey (currently an unofficial/unregistered party)</p>
-    <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=korsanparti">#korsanparti</a></p>
-    <div class="line"></div>
-    <p><strong>party</strong>: Pirate Party of India (currently an unofficial/unregistered party)</p>
-    <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=piratepin">#piratepin</a></p>
-    <div class="line"></div>
-    <p><strong>party</strong>: Pirate Party of Russia (currently an unofficial/unregistered party)</p>
-    <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=ppru">#ppru</a></p>
+    <p><strong>party</strong>: Indian Pirates (currently an unofficial/unregistered party)</p>
+    <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=piratesin">#piratesin</a></p>
     <div class="line"></div>
     <p><strong>party</strong>: Pirate Party of Argentina (currently an unofficial/unregistered party)</p>
     <p><strong>channel</strong>: <a href="https://webchat.pirateirc.net/?channels=ppar">#ppar</a></p>


### PR DESCRIPTION
The channel (and preferred spelling) of Indian Pirates is #piratesin and
PPFI has moved to #piraatit a long time ago.