### PR TITLE
enable git Large File Storage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.png filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
If this was done properly, the images would be erased from the history
and added again, but I don't think I can do that. I hope that this will
help in the future though and the existing files were so small so that
they don't matter.

See also https://git-lfs.github.com/