### PR TITLE
servers.html: update my PGP fingerprint

### DIFF
--- a/www/servers.html
+++ b/www/servers.html
@@ -50,7 +50,7 @@
       <h3>Roubaix-fr.pirateirc.net</h3>
       <p><strong>location</strong>: Roubaix, France</br>
       <strong>party</strong>: Piraattipuolue Finland</br>
-      <strong>staff</strong>: <a href="mailto:mikaela.suomalainen@piraattipuolue.fi">Mikaela</a> (PGP: <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/29104A46C5615BF978A083F20C207F07B2F32B67">2910 4A46 C561 5BF9 78A0 83F2 0C20 7F07 B2F3 2B67</a>), <a href="mailto:ari-martti.hopiavuori@piraattipuolue.fi">AriMartti</a>, <a href="mailto:scoffa@pirateirc.net">Scoffa</a></br>
+      <strong>staff</strong>: <a href="mailto:mikaela.suomalainen@piraattipuolue.fi">Mikaela</a> (PGP: <a href="https://keys.openpgp.org/vks/v1/by-fingerprint/69FF455A869F9031A691E0F199392F62BAE30723">69FF 455A 869F 9031 A691  E0F1 9939 2F62 BAE3 0723</a>), <a href="mailto:ari-martti.hopiavuori@piraattipuolue.fi">AriMartti</a>, <a href="mailto:scoffa@pirateirc.net">Scoffa</a></br>
       <strong>features</strong>: IPv4, SSL (commercial / verifiable), SASL, Tor, Yggdrasil</br>
       <ul>Alternative connection points
       <li><strong>Tor</strong>: <code>tll4bxf546kzf6iv4n2m4pbbjnifrfewe3kcritva2tuuuiowygx2cqd.onion</code>


### PR DESCRIPTION
I forgot to report that I rotated my PGP key recently to move from RSA 4096 to Ed25519.

This information can be confirmed from the old key, which should have a revocation certificate everywhere saying that it's replaced with the new key, it reads on https://mikaela.info/ and https://keybase.io/mikaela and please feel free to check with me using any other channel too.